### PR TITLE
Fix: Support extraction of video ID from YouTube short URLs

### DIFF
--- a/src/lib/googleapis/SpreadSheetService.ts
+++ b/src/lib/googleapis/SpreadSheetService.ts
@@ -35,9 +35,6 @@ export class SpreadSheetService extends GoogleApiBase {
 
         const parsed_response = SheetResponseSchema.parse(response);
 
-        const youtube_video_id_reg =
-            /^https:\/\/www\.youtube\.com\/watch\?v=([^&]+)/;
-
         const songs: Song[] = parsed_response.sheets[0].data[0].rowData
             .map((row) => {
                 if (
@@ -50,19 +47,33 @@ export class SpreadSheetService extends GoogleApiBase {
                     )
                 )
                     return null;
-                const youtube_video_id = youtube_video_id_reg.exec(
+                const youtube_video_id = this.extractYouTubeVideoId(
                     row.values[0].hyperlink,
                 );
                 return {
                     name: "",
                     name_and_artist: row.values[0].formattedValue,
                     youtube_video_id: youtube_video_id
-                        ? youtube_video_id[1]
+                        ? youtube_video_id
                         : undefined,
                 };
             })
             .filter<Song>((value) => value != null);
 
         return songs;
+    }
+
+    private extractYouTubeVideoId(url: string): string | null {
+        const watch_url_pattern =
+            /^https:\/\/www\.youtube\.com\/watch\?v=([^&]+)/;
+        const short_url_pattern = /^https:\/\/www\.youtu.be\/([^?]+)/;
+
+        const watch_url_matched = watch_url_pattern.exec(url);
+        if (watch_url_matched) return watch_url_matched[1];
+
+        const short_url_matched = short_url_pattern.exec(url);
+        if (short_url_matched) return short_url_matched[1];
+
+        return null;
     }
 }

--- a/test/lib/googleapis/SpreadSheetService.test.ts
+++ b/test/lib/googleapis/SpreadSheetService.test.ts
@@ -38,7 +38,7 @@ describe("SpreadSheetService", () => {
             rowData: [
                 {values: [{formattedValue: "Song0/Artist0", hyperlink: "https://www.youtube.com/watch?v=video_id_0"}]},
                 {values: [{formattedValue: "Song1/Artist1", hyperlink: "https://www.youtube.com/watch?v=video_id_1"}]},
-                {values: [{formattedValue: "Song2/Artist2", hyperlink: "https://www.youtube.com/watch?v=video_id_2"}]},
+                {values: [{formattedValue: "Song2/Artist2", hyperlink: "https://youtu.be/testVideoId?si=s3YiFGS9nunWdRlW"}]},
                 {values: [{formattedValue: "Song3/Artist3", hyperlink: "https://www.youtube.com/watch?v=video_id_3"}]},
             ],
         }]
@@ -57,7 +57,12 @@ describe("SpreadSheetService", () => {
                 return {name: "", name_and_artist: row.values![0].formattedValue!, youtube_video_id: ""};
             } else {
                 const matched_youtube_video_id = /https:\/\/www\.youtube\.com\/watch\?v=(.+)/.exec(row.values![0].hyperlink);
-                const youtube_video_id = matched_youtube_video_id ? matched_youtube_video_id[1] : "";
+                const matched_short_youtube_video_id = /https:\/\/youtu.be\/([^?]+)/.exec(row.values![0].hyperlink);
+                const youtube_video_id = matched_youtube_video_id
+                                            ? matched_youtube_video_id[1]
+                                            : matched_short_youtube_video_id
+                                                ? matched_short_youtube_video_id[1]
+                                                : "";
                 return {name: "", name_and_artist: row.values![0].formattedValue!, youtube_video_id: youtube_video_id};
             }
         }


### PR DESCRIPTION
This PR fixes an issue where videos with YouTube short URLs (e.g., youtu.be/...) could not be added to playlists due to missing video ID extraction.

Changes:
- Updated the video ID extraction logic to handle short URL formats
- Ensured compatibility with both standard and short YouTube URLs

This resolves the bug tracked in the `hotfix/YouTube-playlist-add-missing` branch.
