### PR TITLE
sort-YouTube-playlist-same-as-sheet

### DIFF
--- a/src/lib/googleapis/YouTubeService.ts
+++ b/src/lib/googleapis/YouTubeService.ts
@@ -32,7 +32,6 @@ export class YouTubeService extends GoogleApiBase implements PlaylistManager {
         const current_playlist_ids = await this.getPlaylistItems();
 
         console.log("Srart to delete playlist.");
-
         const delete_ids = current_playlist_ids
             .filter((old) => !video_ids.includes(old.video_id))
             .map((to_delete) => to_delete.id);
@@ -40,15 +39,14 @@ export class YouTubeService extends GoogleApiBase implements PlaylistManager {
 
         // Add defferent songs in playlist.
         console.log("Srart to add items to playlist.");
-
-        const add_ids = video_ids.filter(
-            (id) =>
+        const add_items = video_ids.map((id, i) => ({id, position: i})).filter(
+            (item) =>
                 !current_playlist_ids
                     .map((id_set) => id_set.video_id)
-                    .includes(id),
+                    .includes(item.id),
         );
 
-        await this.addItemsToPlaylist(add_ids);
+        await this.addItemsToPlaylist(add_items);
 
         return unfoundSongs;
     }
@@ -98,7 +96,7 @@ export class YouTubeService extends GoogleApiBase implements PlaylistManager {
         });
     }
 
-    private async addItemsToPlaylist(ids: string[]): Promise<void> {
+    private async addItemsToPlaylist(items: {id: string; position: number;}[]): Promise<void> {
         const options = {
             headers: {
                 Authorization: `Bearer ${this.access_token}`,
@@ -107,14 +105,15 @@ export class YouTubeService extends GoogleApiBase implements PlaylistManager {
             muteHttpExceptions: true,
         };
 
-        ids.forEach(async (id) => {
+        items.forEach(async (item) => {
             const body = {
                 snippet: {
                     playlistId: this.playlist_id,
                     resourceId: {
                         kind: "youtube#video",
-                        videoId: id,
+                        videoId: item.id,
                     },
+                    position: item.position,
                 },
             };
 

--- a/test/lib/googleapis/YouTubeService.test.ts
+++ b/test/lib/googleapis/YouTubeService.test.ts
@@ -169,29 +169,35 @@ describe("YouTubeService", () => {
     });
 
     describe("refreshPlaylistWith", () => {
-        // old playlist id: 0 to 3
-        // new playlist id: 2 to 5
-        // playlist id to reduce:      0, 1
-        // playlist id not to touch:   2, 3
-        // playlist id to add:         4, 5
-        const songs: Song[] = [...Array(4)].map((_, num) => ({name: `name_${num+2}`, name_and_artist: `n_and_a_${num+2}`, youtube_video_id: `video_id_${num+2}`}));
-        const old_id_indexs = [...Array(4)].map((_, num) => num);
-        const old_playlist_item_ids = old_id_indexs.map((_, num) => `pl_itm_id_${num}`);
-        const old_video_ids = old_id_indexs.map((_, num) => `video_id_${num}`);
+        type id_position = {
+            pl_itm_id: string;
+            video_id: string;
+            position: number | undefined;
+        };
 
-        const playlist_item_ids_to_reduce = ["pl_itm_id_0", "pl_itm_id_1"];
-        const playlist_item_ids_not_to_touch = ["pl_itm_id_2", "pl_itm_id_3"];
-        const video_ids_not_to_touch = ["video_id_2", "video_id_3"];
-        const video_ids_to_add = ["video_id_4", "video_id_5"];
+        // old playlist id: 0, 1,       4 ,5
+        // new playlist id:    1, 2, 3,    5,    7
+        // playlist id to reduce:      0, 4
+        // playlist id not to touch:   1, 5
+        // playlist id to add:         2, 3, 7
+        const old_id_indexs = [0, 1,       4 ,5];
+        const new_id_indexs = [   1, 2, 3,    5,    7];
+        const songs: Song[] =
+            new_id_indexs.map((num) => ({name: `name_${num}`, name_and_artist: `n_and_a_${num}`, youtube_video_id: `video_id_${num}`}));
+        const old_ids: id_position[] =
+            old_id_indexs.map((num, i) => ({pl_itm_id: `pl_itm_id_${num}`, video_id: `video_id_${num}`, position: i}));
 
+        const reduce_ids: id_position[] = [0, 4].map((num) => ({pl_itm_id: `pl_itm_id_${num}`, video_id: `video_id_${num}`, position: undefined}));
+        const no_touch_ids: id_position[] = [1, 5].map((num) => ({pl_itm_id: `pl_itm_id_${num}`, video_id: `video_id_${num}`, position: undefined}));
+        const add_ids: id_position[] = [{i: 2, p: 1}, {i: 3, p: 2}, {i: 7, p: 4}].map(({i:num, p: pos}) => ({pl_itm_id: `pl_itm_id_${num}`, video_id: `video_id_${num}`, position: pos}));
         
         const playlist_url = `${mocked_endpoint}/playlistItems`;
 
-        const playlist_resource_items = [...Array(4)].map(
-            (_, i) => ({
+        const playlist_resource_items = old_ids.map(
+            (id) => ({
                 ...generateMock(YouTubePlaylistItemResourceSchema),
-                id: old_playlist_item_ids[i],
-                snippet: {resourceId: {kind: "test_kind", videoId: old_video_ids[i]}}
+                id: id.pl_itm_id,
+                snippet: {resourceId: {kind: "test_kind", videoId: id.video_id}},
             })
         );
 
@@ -238,7 +244,7 @@ describe("YouTubeService", () => {
         });
 
         test("Remove different songs of playlist.", async () => {
-            const delete_playlist_item_url_and_queries = playlist_item_ids_to_reduce.map((id) => `${playlist_url}?id=${id}`);
+            const delete_playlist_item_url_and_queries = reduce_ids.map((id) => `${playlist_url}?id=${id.pl_itm_id}`);
 
             await service.init();
             await service.refreshPlaylistWith(songs);
@@ -247,22 +253,22 @@ describe("YouTubeService", () => {
         });
 
         test("Do not remove the same songs in new and old playlist.", async () => {
-            const not_called_delete_playlist_item_url_and_queries = playlist_item_ids_not_to_touch.map((id) => `${playlist_url}?id=${id}`);
+            const not_called_delete_playlist_item_url_and_queries = no_touch_ids.map((id) => `${playlist_url}?id=${id.pl_itm_id}`);
             
             await service.init();
             await service.refreshPlaylistWith(songs);
 
-            not_called_delete_playlist_item_url_and_queries.forEach((url_and_query) => expect(deleteMock).not.toHaveBeenCalledWith(url_and_query, get_options));
+            not_called_delete_playlist_item_url_and_queries.forEach((url_and_query) => expect(deleteMock).not.toHaveBeenCalledWith(url_and_query, expect.objectContaining((get_options))));
         });
 
         test("Add difference of songs from video id to playlist.", async () => {
             const add_url_and_query = `${playlist_url}?part=snippet`
-            const bodies = video_ids_to_add.map((id) => (JSON.stringify({
+            const bodies = add_ids.map((id) => (JSON.stringify({
                 snippet: {
                     playlistId: mocked_playlist_id,
                     resourceId: {
                         kind: "youtube#video",
-                        videoId: id,
+                        videoId: id.video_id,
                     }
                 }
             })));
@@ -277,12 +283,12 @@ describe("YouTubeService", () => {
 
         test("Do not add the same songs in new and old playlist.", async () => {
             const add_url_and_query = `${playlist_url}?part=snippet`
-            const not_called_bodies = video_ids_not_to_touch.map((id) => (JSON.stringify({
+            const not_called_bodies = no_touch_ids.map((id) => (JSON.stringify({
                 snippet: {
                     playlistId: mocked_playlist_id,
                     resourceId: {
                         kind: "youtube#video",
-                        videoId: id,
+                        videoId: id.video_id,
                     }
                 }
             })));
@@ -291,20 +297,20 @@ describe("YouTubeService", () => {
             await service.refreshPlaylistWith(songs);
 
             not_called_bodies.forEach((body) => {
-                expect(postMock).not.toHaveBeenCalledWith(add_url_and_query, { ...json_options, payload: body });
+                expect(postMock).not.toHaveBeenCalledWith(add_url_and_query, expect.objectContaining(({ ...json_options, payload: body })));
             });
         });
 
         test("All fetch of refreshing playlist", async () => {
             const get_playlist_url_and_query = `${playlist_url}?part=id,snippet&playlistId=${mocked_playlist_id}&mine=true&maxResults=50`;
-            const delete_playlist_item_url_and_queries = playlist_item_ids_to_reduce.map((id) => `${playlist_url}?id=${id}`);
+            const delete_playlist_item_url_and_queries = reduce_ids.map((id) => `${playlist_url}?id=${id.pl_itm_id}`);
             const add_url_and_query = `${playlist_url}?part=snippet`
-            const bodies = video_ids_to_add.map((video_id) => (JSON.stringify({
+            const bodies = add_ids.map((id) => (JSON.stringify({
                 snippet: {
                     playlistId: mocked_playlist_id,
                     resourceId: {
                         kind: "youtube#video",
-                        videoId: video_id,
+                        videoId: id.video_id,
                     }
                 }
             })));
@@ -325,14 +331,14 @@ describe("YouTubeService", () => {
             mocked_refreshed_access_token_response.access_token = refreshed_access_token;
 
             const get_playlist_url_and_query = `${playlist_url}?part=id,snippet&playlistId=${mocked_playlist_id}&mine=true&maxResults=50`;
-            const delete_playlist_item_url_and_queries = playlist_item_ids_to_reduce.map((id) => `${playlist_url}?id=${id}`);
+            const delete_playlist_item_url_and_queries = reduce_ids.map((id) => `${playlist_url}?id=${id.pl_itm_id}`);
             const add_url_and_query = `${playlist_url}?part=snippet`
-            const bodies = video_ids_to_add.map((video_id) => (JSON.stringify({
+            const bodies = add_ids.map((id) => (JSON.stringify({
                 snippet: {
                     playlistId: mocked_playlist_id,
                     resourceId: {
                         kind: "youtube#video",
-                        videoId: video_id,
+                        videoId: id.video_id,
                     }
                 }
             })));


### PR DESCRIPTION
###Summary
Previously, new songs are inserted last index. This caused to the mismatch between Sheet and YouTube playlist.

###Changes
- Added positions for insert url fetch.
- Improved diff-based logic to add each proper position.

###Impact
Reduce the mismatch between Sheet and YouTube playlist.