### PR TITLE
feat: Automate Google OAuth token acquisition and add GitHub Pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -130,7 +130,7 @@
 
 <nav>
   <a href="#overview">Overview</a>
-  <a href="#privacy">Privacy Policy</a>
+  <a href="privacy.html">Privacy Policy</a>
   <a href="https://github.com/Yuzucchi-cist/Assigned-song-playlist-manager">GitHub</a>
 </nav>
 
@@ -161,74 +161,6 @@
         <tr><td>Spotify Web API</td><td>プレイリストの取得・追加・削除 / Get, add, and delete playlist items</td></tr>
       </tbody>
     </table>
-  </section>
-
-  <!-- Privacy Policy -->
-  <section id="privacy">
-    <h2>プライバシーポリシー / Privacy Policy</h2>
-    <p class="updated">最終更新 / Last updated: 2026-02-27</p>
-
-    <!-- Japanese -->
-    <div class="lang-block">
-      <div class="lang-label">日本語</div>
-
-      <h4>収集する情報</h4>
-      <p>本アプリケーションは、以下の情報にアクセスします。</p>
-      <ul>
-        <li><strong>Google スプレッドシートのデータ</strong>: 曲名・アーティスト名・YouTube リンクを含む、スプレッドシートの指定セル範囲の内容（読み取り専用）</li>
-        <li><strong>YouTube プレイリストのデータ</strong>: 同期対象のプレイリストに含まれる動画 ID・プレイリストアイテム ID</li>
-        <li><strong>Spotify プレイリストのデータ</strong>: 同期対象のプレイリストに含まれるトラック情報</li>
-      </ul>
-
-      <h4>情報の利用目的</h4>
-      <p>取得したデータは、YouTube および Spotify のプレイリストをスプレッドシートの曲リストと同期する目的にのみ使用します。</p>
-
-      <h4>データの保存</h4>
-      <ul>
-        <li>アクセストークンは Google Apps Script の Script Properties に保存され、スクリプトの実行に必要な期間のみ保持されます。</li>
-        <li>スプレッドシートや各プレイリストの内容を外部サーバーへ送信・保存することは一切ありません。</li>
-      </ul>
-
-      <h4>第三者への開示</h4>
-      <p>取得した情報を第三者に開示・販売・共有することはありません。</p>
-
-      <h4>アクセス権限</h4>
-      <p>本アプリケーションは、スクリプトを実行したユーザー本人のデータにのみアクセスします。他のユーザーのデータには一切アクセスしません。</p>
-
-      <h4>お問い合わせ</h4>
-      <p>プライバシーに関するご質問は、<a href="https://github.com/Yuzucchi-cist/Assigned-song-playlist-manager/issues">GitHub Issues</a> よりお問い合わせください。</p>
-    </div>
-
-    <!-- English -->
-    <div class="lang-block">
-      <div class="lang-label">English</div>
-
-      <h4>Information We Collect</h4>
-      <p>This application accesses the following information:</p>
-      <ul>
-        <li><strong>Google Spreadsheet data</strong>: Contents of the specified cell range in the spreadsheet, including song titles, artist names, and YouTube links (read-only).</li>
-        <li><strong>YouTube playlist data</strong>: Video IDs and playlist item IDs contained in the target playlist.</li>
-        <li><strong>Spotify playlist data</strong>: Track information contained in the target playlist.</li>
-      </ul>
-
-      <h4>How We Use Information</h4>
-      <p>The retrieved data is used solely for the purpose of synchronizing YouTube and Spotify playlists with the song list in the spreadsheet.</p>
-
-      <h4>Data Storage</h4>
-      <ul>
-        <li>Access tokens are stored in Google Apps Script's Script Properties and are retained only for as long as necessary to execute the script.</li>
-        <li>The contents of the spreadsheet and playlists are never transmitted to or stored on any external server.</li>
-      </ul>
-
-      <h4>Disclosure to Third Parties</h4>
-      <p>We do not disclose, sell, or share any retrieved information with third parties.</p>
-
-      <h4>Data Access</h4>
-      <p>This application accesses only the data of the user who runs the script. It does not access data belonging to any other users.</p>
-
-      <h4>Contact</h4>
-      <p>For privacy-related inquiries, please open an issue on <a href="https://github.com/Yuzucchi-cist/Assigned-song-playlist-manager/issues">GitHub Issues</a>.</p>
-    </div>
   </section>
 
 </main>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Assigned Song Playlist Manager</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #f6f8fa;
+      color: #24292f;
+      line-height: 1.6;
+    }
+
+    header {
+      background: #24292f;
+      color: #fff;
+      padding: 2rem 1rem;
+      text-align: center;
+    }
+
+    header h1 { font-size: 1.8rem; margin-bottom: 0.5rem; }
+    header p  { font-size: 0.95rem; color: #adbac7; }
+
+    nav {
+      background: #fff;
+      border-bottom: 1px solid #d0d7de;
+      text-align: center;
+      padding: 0.5rem 1rem;
+    }
+
+    nav a {
+      display: inline-block;
+      margin: 0 0.75rem;
+      color: #0969da;
+      text-decoration: none;
+      font-size: 0.9rem;
+    }
+
+    nav a:hover { text-decoration: underline; }
+
+    main {
+      max-width: 820px;
+      margin: 2rem auto;
+      padding: 0 1rem;
+    }
+
+    section {
+      background: #fff;
+      border: 1px solid #d0d7de;
+      border-radius: 6px;
+      padding: 1.5rem 2rem;
+      margin-bottom: 1.5rem;
+    }
+
+    h2 {
+      font-size: 1.25rem;
+      border-bottom: 1px solid #d0d7de;
+      padding-bottom: 0.5rem;
+      margin-bottom: 1rem;
+    }
+
+    h3 { font-size: 1rem; margin: 1.2rem 0 0.4rem; color: #57606a; }
+    h4 { font-size: 0.9rem; margin: 1rem 0 0.3rem; }
+
+    p  { margin-bottom: 0.75rem; font-size: 0.95rem; }
+    ul { padding-left: 1.4rem; margin-bottom: 0.75rem; font-size: 0.95rem; }
+    li { margin-bottom: 0.25rem; }
+
+    .lang-block {
+      border-left: 3px solid #d0d7de;
+      padding-left: 1rem;
+      margin-bottom: 1.2rem;
+    }
+
+    .lang-label {
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      color: #57606a;
+      text-transform: uppercase;
+      margin-bottom: 0.5rem;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.9rem;
+      margin-bottom: 0.75rem;
+    }
+
+    th, td {
+      border: 1px solid #d0d7de;
+      padding: 0.5rem 0.75rem;
+      text-align: left;
+    }
+
+    th { background: #f6f8fa; font-weight: 600; }
+
+    .updated {
+      font-size: 0.8rem;
+      color: #57606a;
+      margin-bottom: 1rem;
+    }
+
+    footer {
+      text-align: center;
+      padding: 1.5rem 1rem;
+      font-size: 0.8rem;
+      color: #57606a;
+    }
+
+    footer a { color: #0969da; text-decoration: none; }
+    footer a:hover { text-decoration: underline; }
+
+    @media (max-width: 600px) {
+      section { padding: 1rem; }
+      header h1 { font-size: 1.3rem; }
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <h1>Assigned Song Playlist Manager</h1>
+  <p>Google Apps Script for automatic playlist synchronization</p>
+</header>
+
+<nav>
+  <a href="#overview">Overview</a>
+  <a href="#privacy">Privacy Policy</a>
+  <a href="https://github.com/Yuzucchi-cist/Assigned-song-playlist-manager">GitHub</a>
+</nav>
+
+<main>
+
+  <!-- Overview -->
+  <section id="overview">
+    <h2>概要 / Overview</h2>
+
+    <div class="lang-block">
+      <div class="lang-label">日本語</div>
+      <p>Google スプレッドシートに記載された曲リスト（YouTube リンク付き）を読み取り、指定した YouTube プレイリストおよび Spotify プレイリストの内容をそのリストと一致するよう自動更新する Google Apps Script です。</p>
+    </div>
+
+    <div class="lang-block">
+      <div class="lang-label">English</div>
+      <p>A Google Apps Script that reads a song list (with YouTube links) from a Google Spreadsheet and automatically updates the specified YouTube and Spotify playlists to match that list.</p>
+    </div>
+
+    <h3>使用する API / APIs Used</h3>
+    <table>
+      <thead>
+        <tr><th>API</th><th>用途 / Purpose</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Google Sheets API</td><td>スプレッドシートから曲リストを読み取る / Read song list from spreadsheet</td></tr>
+        <tr><td>YouTube Data API v3</td><td>プレイリストの取得・追加・削除 / Get, add, and delete playlist items</td></tr>
+        <tr><td>Spotify Web API</td><td>プレイリストの取得・追加・削除 / Get, add, and delete playlist items</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- Privacy Policy -->
+  <section id="privacy">
+    <h2>プライバシーポリシー / Privacy Policy</h2>
+    <p class="updated">最終更新 / Last updated: 2026-02-27</p>
+
+    <!-- Japanese -->
+    <div class="lang-block">
+      <div class="lang-label">日本語</div>
+
+      <h4>収集する情報</h4>
+      <p>本アプリケーションは、以下の情報にアクセスします。</p>
+      <ul>
+        <li><strong>Google スプレッドシートのデータ</strong>: 曲名・アーティスト名・YouTube リンクを含む、スプレッドシートの指定セル範囲の内容（読み取り専用）</li>
+        <li><strong>YouTube プレイリストのデータ</strong>: 同期対象のプレイリストに含まれる動画 ID・プレイリストアイテム ID</li>
+        <li><strong>Spotify プレイリストのデータ</strong>: 同期対象のプレイリストに含まれるトラック情報</li>
+      </ul>
+
+      <h4>情報の利用目的</h4>
+      <p>取得したデータは、YouTube および Spotify のプレイリストをスプレッドシートの曲リストと同期する目的にのみ使用します。</p>
+
+      <h4>データの保存</h4>
+      <ul>
+        <li>アクセストークンは Google Apps Script の Script Properties に保存され、スクリプトの実行に必要な期間のみ保持されます。</li>
+        <li>スプレッドシートや各プレイリストの内容を外部サーバーへ送信・保存することは一切ありません。</li>
+      </ul>
+
+      <h4>第三者への開示</h4>
+      <p>取得した情報を第三者に開示・販売・共有することはありません。</p>
+
+      <h4>アクセス権限</h4>
+      <p>本アプリケーションは、スクリプトを実行したユーザー本人のデータにのみアクセスします。他のユーザーのデータには一切アクセスしません。</p>
+
+      <h4>お問い合わせ</h4>
+      <p>プライバシーに関するご質問は、<a href="https://github.com/Yuzucchi-cist/Assigned-song-playlist-manager/issues">GitHub Issues</a> よりお問い合わせください。</p>
+    </div>
+
+    <!-- English -->
+    <div class="lang-block">
+      <div class="lang-label">English</div>
+
+      <h4>Information We Collect</h4>
+      <p>This application accesses the following information:</p>
+      <ul>
+        <li><strong>Google Spreadsheet data</strong>: Contents of the specified cell range in the spreadsheet, including song titles, artist names, and YouTube links (read-only).</li>
+        <li><strong>YouTube playlist data</strong>: Video IDs and playlist item IDs contained in the target playlist.</li>
+        <li><strong>Spotify playlist data</strong>: Track information contained in the target playlist.</li>
+      </ul>
+
+      <h4>How We Use Information</h4>
+      <p>The retrieved data is used solely for the purpose of synchronizing YouTube and Spotify playlists with the song list in the spreadsheet.</p>
+
+      <h4>Data Storage</h4>
+      <ul>
+        <li>Access tokens are stored in Google Apps Script's Script Properties and are retained only for as long as necessary to execute the script.</li>
+        <li>The contents of the spreadsheet and playlists are never transmitted to or stored on any external server.</li>
+      </ul>
+
+      <h4>Disclosure to Third Parties</h4>
+      <p>We do not disclose, sell, or share any retrieved information with third parties.</p>
+
+      <h4>Data Access</h4>
+      <p>This application accesses only the data of the user who runs the script. It does not access data belonging to any other users.</p>
+
+      <h4>Contact</h4>
+      <p>For privacy-related inquiries, please open an issue on <a href="https://github.com/Yuzucchi-cist/Assigned-song-playlist-manager/issues">GitHub Issues</a>.</p>
+    </div>
+  </section>
+
+</main>
+
+<footer>
+  <p>
+    <a href="https://github.com/Yuzucchi-cist/Assigned-song-playlist-manager">GitHub Repository</a>
+    &nbsp;|&nbsp;
+    License: ISC
+  </p>
+</footer>
+
+</body>
+</html>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy - Assigned Song Playlist Manager</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #f6f8fa;
+      color: #24292f;
+      line-height: 1.6;
+    }
+
+    header {
+      background: #24292f;
+      color: #fff;
+      padding: 2rem 1rem;
+      text-align: center;
+    }
+
+    header h1 { font-size: 1.8rem; margin-bottom: 0.5rem; }
+    header p  { font-size: 0.95rem; color: #adbac7; }
+
+    nav {
+      background: #fff;
+      border-bottom: 1px solid #d0d7de;
+      text-align: center;
+      padding: 0.5rem 1rem;
+    }
+
+    nav a {
+      display: inline-block;
+      margin: 0 0.75rem;
+      color: #0969da;
+      text-decoration: none;
+      font-size: 0.9rem;
+    }
+
+    nav a:hover { text-decoration: underline; }
+
+    main {
+      max-width: 820px;
+      margin: 2rem auto;
+      padding: 0 1rem;
+    }
+
+    section {
+      background: #fff;
+      border: 1px solid #d0d7de;
+      border-radius: 6px;
+      padding: 1.5rem 2rem;
+      margin-bottom: 1.5rem;
+    }
+
+    h2 {
+      font-size: 1.25rem;
+      border-bottom: 1px solid #d0d7de;
+      padding-bottom: 0.5rem;
+      margin-bottom: 1rem;
+    }
+
+    h4 { font-size: 0.9rem; margin: 1rem 0 0.3rem; }
+
+    p  { margin-bottom: 0.75rem; font-size: 0.95rem; }
+    ul { padding-left: 1.4rem; margin-bottom: 0.75rem; font-size: 0.95rem; }
+    li { margin-bottom: 0.25rem; }
+
+    .lang-block {
+      border-left: 3px solid #d0d7de;
+      padding-left: 1rem;
+      margin-bottom: 1.2rem;
+    }
+
+    .lang-label {
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      color: #57606a;
+      text-transform: uppercase;
+      margin-bottom: 0.5rem;
+    }
+
+    .updated {
+      font-size: 0.8rem;
+      color: #57606a;
+      margin-bottom: 1rem;
+    }
+
+    footer {
+      text-align: center;
+      padding: 1.5rem 1rem;
+      font-size: 0.8rem;
+      color: #57606a;
+    }
+
+    footer a { color: #0969da; text-decoration: none; }
+    footer a:hover { text-decoration: underline; }
+
+    @media (max-width: 600px) {
+      section { padding: 1rem; }
+      header h1 { font-size: 1.3rem; }
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <h1>Assigned Song Playlist Manager</h1>
+  <p>Privacy Policy / プライバシーポリシー</p>
+</header>
+
+<nav>
+  <a href="index.html">Home</a>
+  <a href="https://github.com/Yuzucchi-cist/Assigned-song-playlist-manager">GitHub</a>
+</nav>
+
+<main>
+
+  <section>
+    <h2>プライバシーポリシー / Privacy Policy</h2>
+    <p class="updated">最終更新 / Last updated: 2026-02-27</p>
+
+    <!-- Japanese -->
+    <div class="lang-block">
+      <div class="lang-label">日本語</div>
+
+      <h4>収集する情報</h4>
+      <p>本アプリケーションは、以下の情報にアクセスします。</p>
+      <ul>
+        <li><strong>Google スプレッドシートのデータ</strong>: 曲名・アーティスト名・YouTube リンクを含む、スプレッドシートの指定セル範囲の内容（読み取り専用）</li>
+        <li><strong>YouTube プレイリストのデータ</strong>: 同期対象のプレイリストに含まれる動画 ID・プレイリストアイテム ID</li>
+        <li><strong>Spotify プレイリストのデータ</strong>: 同期対象のプレイリストに含まれるトラック情報</li>
+      </ul>
+
+      <h4>情報の利用目的</h4>
+      <p>取得したデータは、YouTube および Spotify のプレイリストをスプレッドシートの曲リストと同期する目的にのみ使用します。</p>
+
+      <h4>データの保存</h4>
+      <ul>
+        <li>アクセストークンは Google Apps Script の Script Properties に保存され、スクリプトの実行に必要な期間のみ保持されます。</li>
+        <li>スプレッドシートや各プレイリストの内容を外部サーバーへ送信・保存することは一切ありません。</li>
+      </ul>
+
+      <h4>第三者への開示</h4>
+      <p>取得した情報を第三者に開示・販売・共有することはありません。</p>
+
+      <h4>アクセス権限</h4>
+      <p>本アプリケーションは、スクリプトを実行したユーザー本人のデータにのみアクセスします。他のユーザーのデータには一切アクセスしません。</p>
+
+      <h4>お問い合わせ</h4>
+      <p>プライバシーに関するご質問は、<a href="https://github.com/Yuzucchi-cist/Assigned-song-playlist-manager/issues">GitHub Issues</a> よりお問い合わせください。</p>
+    </div>
+
+    <!-- English -->
+    <div class="lang-block">
+      <div class="lang-label">English</div>
+
+      <h4>Information We Collect</h4>
+      <p>This application accesses the following information:</p>
+      <ul>
+        <li><strong>Google Spreadsheet data</strong>: Contents of the specified cell range in the spreadsheet, including song titles, artist names, and YouTube links (read-only).</li>
+        <li><strong>YouTube playlist data</strong>: Video IDs and playlist item IDs contained in the target playlist.</li>
+        <li><strong>Spotify playlist data</strong>: Track information contained in the target playlist.</li>
+      </ul>
+
+      <h4>How We Use Information</h4>
+      <p>The retrieved data is used solely for the purpose of synchronizing YouTube and Spotify playlists with the song list in the spreadsheet.</p>
+
+      <h4>Data Storage</h4>
+      <ul>
+        <li>Access tokens are stored in Google Apps Script's Script Properties and are retained only for as long as necessary to execute the script.</li>
+        <li>The contents of the spreadsheet and playlists are never transmitted to or stored on any external server.</li>
+      </ul>
+
+      <h4>Disclosure to Third Parties</h4>
+      <p>We do not disclose, sell, or share any retrieved information with third parties.</p>
+
+      <h4>Data Access</h4>
+      <p>This application accesses only the data of the user who runs the script. It does not access data belonging to any other users.</p>
+
+      <h4>Contact</h4>
+      <p>For privacy-related inquiries, please open an issue on <a href="https://github.com/Yuzucchi-cist/Assigned-song-playlist-manager/issues">GitHub Issues</a>.</p>
+    </div>
+  </section>
+
+</main>
+
+<footer>
+  <p>
+    <a href="https://github.com/Yuzucchi-cist/Assigned-song-playlist-manager">GitHub Repository</a>
+    &nbsp;|&nbsp;
+    License: ISC
+  </p>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

- `@/googleToken` エイリアスを導入し、GAS 環境（`ScriptApp.getOAuthToken()`）とローカル環境（HTTP コールバックサーバー）で自動的に切り替わる OAuth トークン取得を実装
- `GoogleApisBase` から手動の認証フローを削除し、`initGoogleTokens()` に統一
- テストを `@/googleToken` のモックに対応するよう更新
- `readme.md` のタイポを `README.md` に修正し、GCP OAuth 同意画面用のプライバシーポリシーを追加
- GitHub Pages 用に `docs/index.html` と `docs/privacy.html` を追加

---

- Introduced `@/googleToken` alias to automatically switch between GAS (`ScriptApp.getOAuthToken()`) and local (HTTP callback server) OAuth token acquisition
- Removed manual auth flow from `GoogleApisBase`, unified into `initGoogleTokens()`
- Updated tests to mock `@/googleToken`
- Fixed typo `readme.md` → `README.md` and added Privacy Policy for GCP OAuth consent screen
- Added `docs/index.html` and `docs/privacy.html` for GitHub Pages

## Test plan

- [ ] `npm test` が全テスト（50件）パスすること
- [ ] GAS 上で実行時、`ScriptApp.getOAuthToken()` で自動的にトークンが取得されること
- [ ] ローカル実行時、ブラウザ経由の OAuth フローでトークンが取得されること
- [ ] GitHub Pages で `index.html` / `privacy.html` が正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)