### PR TITLE
docs: add Google Site Verification meta tag

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="google-site-verification" content="OTrAez6EUTAAKcDZbZZqWQ6QReFAUPEYHN_ThzKijJw" />
   <title>Assigned Song Playlist Manager</title>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="google-site-verification" content="OTrAez6EUTAAKcDZbZZqWQ6QReFAUPEYHN_ThzKijJw" />
   <title>Privacy Policy - Assigned Song Playlist Manager</title>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }


### PR DESCRIPTION
## Summary

- `docs/index.html` と `docs/privacy.html` に Google サイト確認用メタタグを追加
- Added Google Site Verification meta tag to `docs/index.html` and `docs/privacy.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)